### PR TITLE
Updates FRI to fix the number of rounds

### DIFF
--- a/code/fri.py
+++ b/code/fri.py
@@ -25,7 +25,7 @@ class Fri:
         while codeword_length > self.expansion_factor and 4*self.num_colinearity_tests < codeword_length:
             codeword_length /= 2
             num_rounds += 1
-        return num_rounds
+        return num_rounds - 1 # the decrement maintains the original behavior
 
     def sample_index( byte_array, size ):
         acc = 0
@@ -61,7 +61,7 @@ class Fri:
         codewords = []
 
         # for each round
-        for r in range(self.num_rounds()):
+        for r in range(self.num_rounds() + 1):
             N = len(codeword)
 
             # make sure omega has the right order
@@ -72,7 +72,7 @@ class Fri:
             proof_stream.push(root)
 
             # prepare next round, but only if necessary
-            if r == self.num_rounds() - 1:
+            if r == self.num_rounds():
                 break
 
             # get challenge
@@ -136,7 +136,7 @@ class Fri:
         # extract all roots and alphas
         roots = []
         alphas = []
-        for r in range(self.num_rounds()):
+        for r in range(self.num_rounds() + 1):
             roots += [proof_stream.pull()]
             alphas += [self.field.sample(proof_stream.verifier_fiat_shamir())]
 
@@ -152,7 +152,7 @@ class Fri:
         degree = (len(last_codeword) // self.expansion_factor) - 1
         last_omega = omega
         last_offset = offset
-        for r in range(self.num_rounds()-1):
+        for r in range(self.num_rounds()):
             last_omega = last_omega^2
             last_offset = last_offset^2
 
@@ -174,10 +174,10 @@ class Fri:
             return False
 
         # get indices
-        top_level_indices = self.sample_indices(proof_stream.verifier_fiat_shamir(), self.domain_length >> 1, self.domain_length >> (self.num_rounds()-1), self.num_colinearity_tests)
+        top_level_indices = self.sample_indices(proof_stream.verifier_fiat_shamir(), self.domain_length >> 1, self.domain_length >> self.num_rounds(), self.num_colinearity_tests)
 
         # for every round, check consistency of subsequent layers
-        for r in range(0, self.num_rounds()-1):
+        for r in range(0, self.num_rounds()):
 
             # fold c indices
             c_indices = [index % (self.domain_length >> (r+1)) for index in top_level_indices]


### PR DESCRIPTION
## Description

This is the minimal set of changes to fix the number of rounds issue with the FRI implementation.


## Task list

- [x]  Update the FRI implementation to collect `r+1` codewords for `r` rounds
- [ ] Review `num_rounds()` implementation

## Explanation

The FRI code is supposed to collect `r+1` codewords for `r` rounds,  but "as is" it is collecting `r` codewords for `r` rounds.

The first step of the fix maintains the original behavior; however the problematic corner case (where a single codeword is collected) will now fail at the assertion:

https://github.com/aszepieniec/stark-anatomy/blob/fce084f66df77b5ce726cafadb1d82144ebf4790/code/fri.py#L20

instead of failing with a RangeError (`codewords[1]`) in the `prove` method:

https://github.com/aszepieniec/stark-anatomy/blob/fce084f66df77b5ce726cafadb1d82144ebf4790/code/fri.py#L122

In order to maintain the original behavior, the return value of `num_rounds()` needs to be decremented:

https://github.com/raugfer/stark-anatomy/blob/92dbd0d3df1c14b6230d46dbb71407c65702f3ab/code/fri.py#L28
```python
        return num_rounds - 1 # the decrement maintains the original behavior
```

However, I think that should not be the case, AFAICT the original code for `num_rounds()` is the one to be maintained:

https://github.com/aszepieniec/stark-anatomy/blob/fce084f66df77b5ce726cafadb1d82144ebf4790/code/fri.py#L28

Nevertheless maintaining the original implementation of `num_rounds()` -- along with this PR remaining changes -- modifies the original behavior, as one extra round will happen.

Therefore one needs to verify which version of `num_rounds()` indeed implements the FRI protocol while guaranteeing its security properties dictated by the parameters `expansion_factor` and `num_colinearity_tests`. 