### PR TITLE
fix infinite loop in Fri.sample_indices()

### DIFF
--- a/code/fri.py
+++ b/code/fri.py
@@ -119,7 +119,7 @@ class Fri:
         codewords = self.commit(codeword, proof_stream)
 
         # get indices
-        top_level_indices = self.sample_indices(proof_stream.prover_fiat_shamir(), len(codewords[0])/2, len(codewords[-1]), self.num_colinearity_tests)
+        top_level_indices = self.sample_indices(proof_stream.prover_fiat_shamir(), len(codewords[0]), len(codewords[-1]), self.num_colinearity_tests)
         indices = [index for index in top_level_indices]
 
         # query phase


### PR DESCRIPTION
# The Issue

test_fri.py, test_stark.py, test_fast_stark.py are unable to complete due to an infinite loop within the Fri prover.


# What Caused It

The previous commit fixed an off by one error within Fri.prove() whereby the length of a one time reduced size codeword was incorrectly being passed in as the original size. 

    top_level_indices = self.sample_indices(
        proof_stream.prover_fiat_shamir(), 
        len(codewords[1]),    # <---- incorrect part on line 122
        len(codewords[-1]),    
        self.num_colinearity_tests
        )

The was changed to:

    top_level_indices = self.sample_indices(
        proof_stream.prover_fiat_shamir(), 
        len(codewords[0])/2,  # <--- correction in the previous commit
        len(codewords[-1]), 
        self.num_colinearity_tests
        )

However, the original value should not have been divided by 2. This results in an infinite loop within Fri.sample_indices(). As a result, the modulo operation on line 34 always results in zero. 

    def sample_index( byte_array, size ):
        acc = 0
        for b in byte_array:
            acc = (acc << 8) ^ int(b)

        return acc % size    # <---- always zero


As a result, within  the while loop in sample_indices(), the length of the indices list never increments beyond 1, causing the infinite loop


    def sample_indices( self, seed, size, reduced_size, number ):
        assert(number <= reduced_size), f"cannot sample more indices than available in last codeword; requested: {number}, available: {reduced_size}"
        assert(number <= 2*reduced_size), "not enough entropy in indices wrt last codeword"

        indices = []
        reduced_indices = []
        counter = 0
        while len(indices) < number:
            index = Fri.sample_index(blake2b(seed + bytes(counter)).digest(), size)
            reduced_index = index % reduced_size
            counter += 1

            if reduced_index not in reduced_indices:  # <---- this is never satisfied
                indices += [index]
                reduced_indices += [reduced_index]

        return indices

# The Fix 

The below change fixes the infinite loop and test_fri.py, test_stark.py, and test_fast_stark.py now pass.


The was changed to:

    top_level_indices = self.sample_indices(
        proof_stream.prover_fiat_shamir(), 
        len(codewords[0]),  # <--- corrected orignal size
        len(codewords[-1]), 
        self.num_colinearity_tests
        )

