### PR TITLE
IOPP: provers commits to transition quotient, not transition zerofier

### DIFF
--- a/docs/stark.md
+++ b/docs/stark.md
@@ -91,7 +91,7 @@ Prover:
  - Compress the $r$ transition constraints into one master constraint that is the weighted sum.
  - Symbolically evaluate the master constraint in the trace polynomials, thus generating the transition polynomial.
  - Divide out the transition zerofier to get the transition quotient.
- - Commit to the transition zerofier.
+ - Commit to the transition quotient.
  - Run FRI on all the committed polynomials: the boundary quotients, the transition quotients, and the transition zerofier.
  - Supply the Merkle leafs and authentication paths that are requested by the verifier.
 


### PR DESCRIPTION
Hi,

Thank you very much for this awesome tutorial! I've learned a lot so far. 

I've just noticed a thing, which is just a typo: But in my understanding in IOPP the prover commits to the transition **quotients** not the **zerofier**. The latter can be efficiently computed by the verifier. 